### PR TITLE
feat: implement custom source to enable server side tracking

### DIFF
--- a/src/Snippets.js
+++ b/src/Snippets.js
@@ -3,26 +3,26 @@ import warn from './utils/warn'
 // https://developers.google.com/tag-manager/quickstart
 
 const Snippets = {
-  tags: function ({ id, events, dataLayer, dataLayerName, preview, auth }) {
+  tags: function ({ id, src, events, dataLayer, dataLayerName, preview, auth }) {
     const gtm_auth = `&gtm_auth=${auth}`
     const gtm_preview = `&gtm_preview=${preview}`
-
+    const gtm_src = src
     if (!id) warn('GTM Id is required')
-    
+
     const iframe = `
-      <iframe src="https://www.googletagmanager.com/ns.html?id=${id}${gtm_auth}${gtm_preview}&gtm_cookies_win=x"
+      <iframe src="${gtm_src}/ns.html?id=${id}${gtm_auth}${gtm_preview}&gtm_cookies_win=x"
         height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`
-  
+
     const script = `
       (function(w,d,s,l,i){w[l]=w[l]||[];
         w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js', ${JSON.stringify(events).slice(1, -1)}});
         var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-        j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'${gtm_auth}${gtm_preview}&gtm_cookies_win=x';
+        j.async=true;j.src='${gtm_src}/gtm.js?id='+i+dl+'${gtm_auth}${gtm_preview}&gtm_cookies_win=x';
         f.parentNode.insertBefore(j,f);
       })(window,document,'script','${dataLayerName}','${id}');`
-  
+
     const dataLayerVar = this.dataLayer(dataLayer, dataLayerName)
-  
+
     return {
       iframe,
       script,

--- a/src/TagManager.js
+++ b/src/TagManager.js
@@ -29,9 +29,10 @@ const TagManager = {
       dataScript
     }
   },
-  initialize: function ({ gtmId, events = {}, dataLayer, dataLayerName = 'dataLayer', auth = '', preview = '' }) {
+  initialize: function ({ gtmId, gtmSrc='https://www.googletagmanager.com', events = {}, dataLayer, dataLayerName = 'dataLayer', auth = '', preview = '' }) {
     const gtm = this.gtm({
       id: gtmId,
+      src: gtmSrc,
       events: events,
       dataLayer: dataLayer || undefined,
       dataLayerName: dataLayerName,


### PR DESCRIPTION
To provide server-side tracking, a custom domain must be provided instead of googletagmanager.com.
